### PR TITLE
Add Longevity World Cup

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,6 +14,7 @@ Learn more about blood testing, biomarkers, tech, and services to help quantify 
 - [Additional Common and Recommended Biomarkers](#additional-common-and-recommended-biomarkers)
 - [Misc Blood Tests](#misc-blood-tests)
 - [Blood Testing Companies](#blood-testing-companies)
+- [Health Tracking and Analytics Tools](#health-tracking-and-analytics-tools)
 - [Books](#books)
 - [Biomarker Tracker](#biomarker-tracker)
 - [How to Use the Blood Tests Tracker](#how-to-use-the-blood-tests-tracker)
@@ -122,6 +123,10 @@ Feel free to use, comment, share, contribute. This is very much a collaborative 
 - Inside Tracker
 - WellnessFX
 - Life Extension
+
+## Health Tracking and Analytics Tools
+
+- [Longevity World Cup](https://github.com/nopara73/LongevityWorldCup) - Open-source longevity sport platform for comparing Pheno Age and Bortz Age results through athlete profiles and public rankings.
 
 ## Books
 


### PR DESCRIPTION
Adds Longevity World Cup as a health tracking and analytics tool.

Why this fits:
- It uses blood-biomarker-derived biological-age clocks, including Pheno Age and Bortz Age.
- It exposes athlete profiles and public rankings for comparing biological-age results.
- It is open source and fits the list's stated scope around quantified health metrics and analytics tools.

Closes #9

No tests were run; this is a README-only resource addition.